### PR TITLE
Fix run_scan working directory

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -15,6 +15,7 @@ fn run_scan(url: String) -> String {
     use std::process::Command;
 
     let output = Command::new("python")
+        .current_dir("..")
         .arg("python/run_scan.py")
         .arg(&url)
         .output()


### PR DESCRIPTION
## Summary
- run Python subprocess from repo root to ensure correct path

## Testing
- `cargo build --quiet` *(fails: failed to download crates)*

------
https://chatgpt.com/codex/tasks/task_e_686c363fd7188323b70765320475816e